### PR TITLE
feat: update for additional prem fee

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "smart-contracts/lib/forge-std"]
 	path = smart-contracts/lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
+[submodule "smart-contracts/lib/solmate"]
+	path = smart-contracts/lib/solmate
+	url = https://github.com/transmissions11/solmate

--- a/smart-contracts/.gitignore
+++ b/smart-contracts/.gitignore
@@ -16,3 +16,5 @@ node_modules
 
 # Hardhat Ignition default folder for deployments against a local node
 ignition/deployments/chain-31337
+
+.DS_Store

--- a/smart-contracts/contracts/MoreMarkets.sol
+++ b/smart-contracts/contracts/MoreMarkets.sol
@@ -10,7 +10,6 @@ import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {IDebtTokenFactory} from "./interfaces/factories/IDebtTokenFactory.sol";
 import {IDebtToken} from "./interfaces/tokens/IDebtToken.sol";
-import "hardhat/console.sol";
 
 // TODO: need to think if we have to move it to library
 error NothingToClaim();

--- a/smart-contracts/contracts/bundlers/BaseBundler.sol
+++ b/smart-contracts/contracts/bundlers/BaseBundler.sol
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.19;
+
+import {IMorphoBundler} from "../interfaces/IMorphoBundler.sol";
+import {IPublicAllocator, Withdrawal} from "../interfaces/IPublicAllocator.sol";
+import {MarketParams, Signature, Authorization, IMorpho} from "@morpho-org/morpho-blue/src/interfaces/IMorpho.sol";
+
+import {ErrorsLib} from "../libraries/ErrorsLib.sol";
+import {SafeTransferLib, ERC20} from "../lib/solmate/src/utils/SafeTransferLib.sol";
+
+import {Multicall} from "./Multicall.sol";
+
+/// @title MorphoBundler
+/// @author Morpho Labs
+/// @custom:contact security@morpho.org
+/// @notice Bundler contract managing interactions with Morpho.
+abstract contract BaseBundler is Multicall, IMorphoBundler {
+    using SafeTransferLib for ERC20;
+
+    /* IMMUTABLES */
+
+    /// @notice The Morpho contract address.
+    IMorpho public immutable MORPHO;
+
+    /* CONSTRUCTOR */
+
+    constructor(address morpho) {
+        require(morpho != address(0), ErrorsLib.ZERO_ADDRESS);
+
+        MORPHO = IMorpho(morpho);
+    }
+
+    /* CALLBACKS */
+
+    function onMorphoSupply(uint256, bytes calldata data) external {
+        // Don't need to approve Morpho to pull tokens because it should already be approved max.
+        _callback(data);
+    }
+
+    function onMorphoSupplyCollateral(uint256, bytes calldata data) external {
+        // Don't need to approve Morpho to pull tokens because it should already be approved max.
+        _callback(data);
+    }
+
+    function onMorphoRepay(uint256, bytes calldata data) external {
+        // Don't need to approve Morpho to pull tokens because it should already be approved max.
+        _callback(data);
+    }
+
+    function onMorphoFlashLoan(uint256, bytes calldata data) external {
+        // Don't need to approve Morpho to pull tokens because it should already be approved max.
+        _callback(data);
+    }
+
+    /* ACTIONS */
+
+    /// @notice Approves `authorization.authorized` to manage `authorization.authorizer`'s position via EIP712
+    /// `signature`.
+    /// @param authorization The `Authorization` struct.
+    /// @param signature The signature.
+    /// @param skipRevert Whether to avoid reverting the call in case the signature is frontrunned.
+    function morphoSetAuthorizationWithSig(
+        Authorization calldata authorization,
+        Signature calldata signature,
+        bool skipRevert
+    ) external payable protected {
+        try MORPHO.setAuthorizationWithSig(authorization, signature) {} catch (
+            bytes memory returnData
+        ) {
+            if (!skipRevert) _revert(returnData);
+        }
+    }
+
+    /// @notice Supplies `assets` of the loan asset on behalf of `onBehalf`.
+    /// @notice The supplied assets cannot be used as collateral but is eligible to earn interest.
+    /// @dev Either `assets` or `shares` should be zero. Most usecases should rely on `assets` as an input so the
+    /// bundler is guaranteed to have `assets` tokens pulled from its balance, but the possibility to mint a specific
+    /// amount of shares is given for full compatibility and precision.
+    /// @dev Initiator must have previously transferred their assets to the bundler.
+    /// @param marketParams The Morpho market to supply assets to.
+    /// @param assets The amount of assets to supply. Pass `type(uint256).max` to supply the bundler's loan asset
+    /// balance.
+    /// @param shares The amount of shares to mint.
+    /// @param slippageAmount The minimum amount of supply shares to mint in exchange for `assets` when it is used.
+    /// The maximum amount of assets to deposit in exchange for `shares` otherwise.
+    /// @param onBehalf The address that will own the increased supply position.
+    /// @param data Arbitrary data to pass to the `onMorphoSupply` callback. Pass empty data if not needed.
+    function morphoSupply(
+        MarketParams calldata marketParams,
+        uint256 assets,
+        uint256 shares,
+        uint256 slippageAmount,
+        address onBehalf,
+        bytes calldata data
+    ) external payable protected {
+        // Do not check `onBehalf` against the zero address as it's done at Morpho's level.
+        require(onBehalf != address(this), ErrorsLib.BUNDLER_ADDRESS);
+
+        // Don't always cap the assets to the bundler's balance because the liquidity can be transferred later
+        // (via the `onMorphoSupply` callback).
+        if (assets == type(uint256).max)
+            assets = ERC20(marketParams.loanToken).balanceOf(address(this));
+
+        _approveMaxTo(marketParams.loanToken, address(MORPHO));
+
+        (uint256 suppliedAssets, uint256 suppliedShares) = MORPHO.supply(
+            marketParams,
+            assets,
+            shares,
+            onBehalf,
+            data
+        );
+
+        if (assets > 0)
+            require(
+                suppliedShares >= slippageAmount,
+                ErrorsLib.SLIPPAGE_EXCEEDED
+            );
+        else
+            require(
+                suppliedAssets <= slippageAmount,
+                ErrorsLib.SLIPPAGE_EXCEEDED
+            );
+    }
+
+    /// @notice Supplies `assets` of collateral on behalf of `onBehalf`.
+    /// @dev Initiator must have previously transferred their assets to the bundler.
+    /// @param marketParams The Morpho market to supply collateral to.
+    /// @param assets The amount of collateral to supply. Pass `type(uint256).max` to supply the bundler's loan asset
+    /// balance.
+    /// @param onBehalf The address that will own the increased collateral position.
+    /// @param data Arbitrary data to pass to the `onMorphoSupplyCollateral` callback. Pass empty data if not needed.
+    function morphoSupplyCollateral(
+        MarketParams calldata marketParams,
+        uint256 assets,
+        address onBehalf,
+        bytes calldata data
+    ) external payable protected {
+        // Do not check `onBehalf` against the zero address as it's done at Morpho's level.
+        require(onBehalf != address(this), ErrorsLib.BUNDLER_ADDRESS);
+
+        // Don't always cap the assets to the bundler's balance because the liquidity can be transferred later
+        // (via the `onMorphoSupplyCollateral` callback).
+        if (assets == type(uint256).max)
+            assets = ERC20(marketParams.collateralToken).balanceOf(
+                address(this)
+            );
+
+        _approveMaxTo(marketParams.collateralToken, address(MORPHO));
+
+        MORPHO.supplyCollateral(marketParams, assets, onBehalf, data);
+    }
+
+    /// @notice Borrows `assets` of the loan asset on behalf of the initiator.
+    /// @dev Either `assets` or `shares` should be zero. Most usecases should rely on `assets` as an input so the
+    /// initiator is guaranteed to borrow `assets` tokens, but the possibility to mint a specific amount of shares is
+    /// given for full compatibility and precision.
+    /// @dev Initiator must have previously authorized the bundler to act on their behalf on Morpho.
+    /// @param marketParams The Morpho market to borrow assets from.
+    /// @param assets The amount of assets to borrow.
+    /// @param shares The amount of shares to mint.
+    /// @param slippageAmount The maximum amount of borrow shares to mint in exchange for `assets` when it is used.
+    /// The minimum amount of assets to borrow in exchange for `shares` otherwise.
+    /// @param receiver The address that will receive the borrowed assets.
+    function morphoBorrow(
+        MarketParams calldata marketParams,
+        uint256 assets,
+        uint256 shares,
+        uint256 slippageAmount,
+        address receiver
+    ) external payable protected {
+        (uint256 borrowedAssets, uint256 borrowedShares) = MORPHO.borrow(
+            marketParams,
+            assets,
+            shares,
+            initiator(),
+            receiver
+        );
+
+        if (assets > 0)
+            require(
+                borrowedShares <= slippageAmount,
+                ErrorsLib.SLIPPAGE_EXCEEDED
+            );
+        else
+            require(
+                borrowedAssets >= slippageAmount,
+                ErrorsLib.SLIPPAGE_EXCEEDED
+            );
+    }
+
+    /// @notice Repays `assets` of the loan asset on behalf of `onBehalf`.
+    /// @dev Either `assets` or `shares` should be zero. Most usecases should rely on `assets` as an input so the
+    /// bundler is guaranteed to have `assets` tokens pulled from its balance, but the possibility to burn a specific
+    /// amount of shares is given for full compatibility and precision.
+    /// @param marketParams The Morpho market to repay assets to.
+    /// @param assets The amount of assets to repay. Pass `type(uint256).max` to repay the bundler's loan asset balance.
+    /// @param shares The amount of shares to burn.
+    /// @param slippageAmount The minimum amount of borrow shares to burn in exchange for `assets` when it is used.
+    /// The maximum amount of assets to deposit in exchange for `shares` otherwise.
+    /// @param onBehalf The address of the owner of the debt position.
+    /// @param data Arbitrary data to pass to the `onMorphoRepay` callback. Pass empty data if not needed.
+    function morphoRepay(
+        MarketParams calldata marketParams,
+        uint256 assets,
+        uint256 shares,
+        uint256 slippageAmount,
+        address onBehalf,
+        bytes calldata data
+    ) external payable protected {
+        // Do not check `onBehalf` against the zero address as it's done at Morpho's level.
+        require(onBehalf != address(this), ErrorsLib.BUNDLER_ADDRESS);
+
+        // Don't always cap the assets to the bundler's balance because the liquidity can be transferred later
+        // (via the `onMorphoRepay` callback).
+        if (assets == type(uint256).max)
+            assets = ERC20(marketParams.loanToken).balanceOf(address(this));
+
+        _approveMaxTo(marketParams.loanToken, address(MORPHO));
+
+        (uint256 repaidAssets, uint256 repaidShares) = MORPHO.repay(
+            marketParams,
+            assets,
+            shares,
+            onBehalf,
+            data
+        );
+
+        if (assets > 0)
+            require(
+                repaidShares >= slippageAmount,
+                ErrorsLib.SLIPPAGE_EXCEEDED
+            );
+        else
+            require(
+                repaidAssets <= slippageAmount,
+                ErrorsLib.SLIPPAGE_EXCEEDED
+            );
+    }
+
+    /// @notice Withdraws `assets` of the loan asset on behalf of the initiator.
+    /// @dev Either `assets` or `shares` should be zero. Most usecases should rely on `assets` as an input so the
+    /// initiator is guaranteed to withdraw `assets` tokens, but the possibility to burn a specific amount of shares is
+    /// given for full compatibility and precision.
+    /// @dev Initiator must have previously authorized the bundler to act on their behalf on Morpho.
+    /// @param marketParams The Morpho market to withdraw assets from.
+    /// @param assets The amount of assets to withdraw.
+    /// @param shares The amount of shares to burn.
+    /// @param slippageAmount The maximum amount of supply shares to burn in exchange for `assets` when it is used.
+    /// The minimum amount of assets to withdraw in exchange for `shares` otherwise.
+    /// @param receiver The address that will receive the withdrawn assets.
+    function morphoWithdraw(
+        MarketParams calldata marketParams,
+        uint256 assets,
+        uint256 shares,
+        uint256 slippageAmount,
+        address receiver
+    ) external payable protected {
+        (uint256 withdrawnAssets, uint256 withdrawnShares) = MORPHO.withdraw(
+            marketParams,
+            assets,
+            shares,
+            initiator(),
+            receiver
+        );
+
+        if (assets > 0)
+            require(
+                withdrawnShares <= slippageAmount,
+                ErrorsLib.SLIPPAGE_EXCEEDED
+            );
+        else
+            require(
+                withdrawnAssets >= slippageAmount,
+                ErrorsLib.SLIPPAGE_EXCEEDED
+            );
+    }
+
+    /// @notice Withdraws `assets` of the collateral asset on behalf of the initiator.
+    /// @dev Initiator must have previously authorized the bundler to act on their behalf on Morpho.
+    /// @param marketParams The Morpho market to withdraw collateral from.
+    /// @param assets The amount of collateral to withdraw.
+    /// @param receiver The address that will receive the collateral assets.
+    function morphoWithdrawCollateral(
+        MarketParams calldata marketParams,
+        uint256 assets,
+        address receiver
+    ) external payable protected {
+        MORPHO.withdrawCollateral(marketParams, assets, initiator(), receiver);
+    }
+
+    /// @notice Triggers a flash loan on Morpho.
+    /// @param token The address of the token to flash loan.
+    /// @param assets The amount of assets to flash loan.
+    /// @param data Arbitrary data to pass to the `onMorphoFlashLoan` callback.
+    function morphoFlashLoan(
+        address token,
+        uint256 assets,
+        bytes calldata data
+    ) external payable protected {
+        _approveMaxTo(token, address(MORPHO));
+
+        MORPHO.flashLoan(token, assets, data);
+    }
+
+    /// @notice Reallocates funds from markets of a vault to another market of that same vault.
+    /// @param publicAllocator The address of the public allocator.
+    /// @param vault The address of the vault.
+    /// @param value The value in ETH to pay for the reallocate fee.
+    /// @param withdrawals The list of markets and corresponding amounts to withdraw.
+    /// @param supplyMarketParams The market receiving the funds.
+    function reallocateTo(
+        address publicAllocator,
+        address vault,
+        uint256 value,
+        Withdrawal[] calldata withdrawals,
+        MarketParams calldata supplyMarketParams
+    ) external payable protected {
+        IPublicAllocator(publicAllocator).reallocateTo{value: value}(
+            vault,
+            withdrawals,
+            supplyMarketParams
+        );
+    }
+
+    /* INTERNAL */
+
+    /// @dev Triggers `_multicall` logic during a callback.
+    function _callback(bytes calldata data) internal {
+        require(msg.sender == address(MORPHO), ErrorsLib.UNAUTHORIZED_SENDER);
+
+        _multicall(abi.decode(data, (bytes[])));
+    }
+
+    /// @inheritdoc BaseBundler
+    function _isSenderAuthorized()
+        internal
+        view
+        virtual
+        override
+        returns (bool)
+    {
+        return super._isSenderAuthorized() || msg.sender == address(MORPHO);
+    }
+}

--- a/smart-contracts/contracts/bundlers/Multicall.sol
+++ b/smart-contracts/contracts/bundlers/Multicall.sol
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.24;
+
+import {IMulticall} from "../interfaces/bundlers/IMulticall.sol";
+
+import {ErrorsLib} from "../libraries/ErrorsLib.sol";
+import {ConstantsLib} from "../libraries/ConstantsLib.sol";
+import {SafeTransferLib, ERC20} from "../lib/solmate/src/utils/SafeTransferLib.sol";
+
+/// @title BaseBundler
+/// @author Morpho Labs
+/// @custom:contact security@morpho.org
+/// @notice Enables calling multiple functions in a single call to the same contract (self).
+/// @dev Every bundler must inherit from this contract.
+/// @dev Every bundler inheriting from this contract must have their external functions payable as they will be
+/// delegate called by the `multicall` function (which is payable, and thus might pass a non-null ETH value). It is
+/// recommended not to rely on `msg.value` as the same value can be reused for multiple calls.
+abstract contract Multicall is IMulticall {
+    using SafeTransferLib for ERC20;
+
+    /* STORAGE */
+
+    /// @notice Keeps track of the bundler's latest bundle initiator.
+    /// @dev Also prevents interacting with the bundler outside of an initiated execution context.
+    address private _initiator = ConstantsLib.UNSET_INITIATOR;
+
+    /* MODIFIERS */
+
+    /// @dev Prevents a function to be called outside an initiated `multicall` context and protects a function from
+    /// being called by an unauthorized sender inside an initiated multicall context.
+    modifier protected() {
+        require(
+            _initiator != ConstantsLib.UNSET_INITIATOR,
+            ErrorsLib.UNINITIATED
+        );
+        require(_isSenderAuthorized(), ErrorsLib.UNAUTHORIZED_SENDER);
+
+        _;
+    }
+
+    /* PUBLIC */
+
+    /// @notice Returns the address of the initiator of the multicall transaction.
+    /// @dev Specialized getter to prevent using `_initiator` directly.
+    function initiator() public view returns (address) {
+        return _initiator;
+    }
+
+    /* EXTERNAL */
+
+    /// @notice Executes a series of delegate calls to the contract itself.
+    /// @dev Locks the initiator so that the sender can uniquely be identified in callbacks.
+    /// @dev All functions delegatecalled must be `payable` if `msg.value` is non-zero.
+    function multicall(bytes[] memory data) external payable {
+        require(
+            _initiator == ConstantsLib.UNSET_INITIATOR,
+            ErrorsLib.ALREADY_INITIATED
+        );
+
+        _initiator = msg.sender;
+
+        _multicall(data);
+
+        _initiator = ConstantsLib.UNSET_INITIATOR;
+    }
+
+    /* INTERNAL */
+
+    /// @dev Executes a series of delegate calls to the contract itself.
+    /// @dev All functions delegatecalled must be `payable` if `msg.value` is non-zero.
+    function _multicall(bytes[] memory data) internal {
+        for (uint256 i; i < data.length; ++i) {
+            (bool success, bytes memory returnData) = address(this)
+                .delegatecall(data[i]);
+
+            // No need to check that `address(this)` has code in case of success.
+            if (!success) _revert(returnData);
+        }
+    }
+
+    /// @dev Bubbles up the revert reason / custom error encoded in `returnData`.
+    /// @dev Assumes `returnData` is the return data of any kind of failing CALL to a contract.
+    function _revert(bytes memory returnData) internal pure {
+        uint256 length = returnData.length;
+        require(length > 0, ErrorsLib.CALL_FAILED);
+
+        assembly ("memory-safe") {
+            revert(add(32, returnData), length)
+        }
+    }
+
+    /// @dev Returns whether the sender of the call is authorized.
+    /// @dev Assumes to be inside a properly initiated `multicall` context.
+    function _isSenderAuthorized() internal view virtual returns (bool) {
+        return msg.sender == _initiator;
+    }
+
+    /// @dev Gives the max approval to `spender` to spend the given `asset` if not already approved.
+    /// @dev Assumes that `type(uint256).max` is large enough to never have to increase the allowance again.
+    function _approveMaxTo(address asset, address spender) internal {
+        if (ERC20(asset).allowance(address(this), spender) == 0) {
+            ERC20(asset).safeApprove(spender, type(uint256).max);
+        }
+    }
+}

--- a/smart-contracts/contracts/interfaces/IMoreMarkets.sol
+++ b/smart-contracts/contracts/interfaces/IMoreMarkets.sol
@@ -19,6 +19,9 @@ struct CategoryInfo {
 }
 
 interface IMoreMarkets is IMorphoBase {
+    /// @notice Emitted `premFee` is set to `newFee`.
+    event SetPremFee(Id indexed id, uint256 premFee);
+
     function position(
         Id id,
         address user

--- a/smart-contracts/contracts/interfaces/bundlers/IMorphoBundler.sol
+++ b/smart-contracts/contracts/interfaces/bundlers/IMorphoBundler.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+import {IMorphoRepayCallback, IMorphoSupplyCallback, IMorphoSupplyCollateralCallback, IMorphoFlashLoanCallback} from "@morpho-org/morpho-blue/src/interfaces/IMorphoCallbacks.sol";
+
+/// @title IMorphoBundler
+/// @author Morpho Labs
+/// @custom:contact security@morpho.org
+/// @notice Interface of MorphoBundler.
+interface IMorphoBundler is
+    IMorphoSupplyCallback,
+    IMorphoRepayCallback,
+    IMorphoSupplyCollateralCallback,
+    IMorphoFlashLoanCallback
+{
+
+}

--- a/smart-contracts/contracts/interfaces/bundlers/IMulticall.sol
+++ b/smart-contracts/contracts/interfaces/bundlers/IMulticall.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title IMulticall
+/// @author Morpho Labs
+/// @custom:contact security@morpho.org
+/// @notice Interface of Multicall.
+interface IMulticall {
+    /// @notice Executes an ordered batch of delegatecalls to this contract.
+    /// @param data The ordered array of calldata to execute.
+    function multicall(bytes[] calldata data) external payable;
+}

--- a/smart-contracts/contracts/interfaces/bundlers/IPublicAllocator.sol
+++ b/smart-contracts/contracts/interfaces/bundlers/IPublicAllocator.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+import {Id, MarketParams, IMorpho} from "@morpho-org/morpho-blue/src/interfaces/IMorpho.sol";
+
+struct FlowCaps {
+    uint128 maxIn;
+    uint128 maxOut;
+}
+
+struct FlowCapsConfig {
+    Id id;
+    FlowCaps caps;
+}
+
+struct Withdrawal {
+    MarketParams marketParams;
+    uint128 amount;
+}
+
+/// @dev Copy of the Public Allocator interface but using the struct of morpho-blue imported by the bundler.
+interface IPublicAllocator {
+    /// @dev Max settable flow cap, such that caps can always be stored on 128 bits.
+    /// @dev The actual max possible flow cap is type(uint128).max-1.
+    /// @dev Equals to 170141183460469231731687303715884105727;
+    uint128 constant MAX_SETTABLE_FLOW_CAP = type(uint128).max / 2;
+
+    function MORPHO() external view returns (IMorpho);
+
+    function owner(address vault) external view returns (address);
+
+    function fee(address vault) external view returns (uint256);
+
+    function accruedFee(address vault) external view returns (uint256);
+
+    function reallocateTo(
+        address vault,
+        Withdrawal[] calldata withdrawals,
+        MarketParams calldata supplyMarketParams
+    ) external payable;
+
+    function setOwner(address vault, address newOwner) external;
+
+    function setFee(address vault, uint256 newFee) external;
+
+    function transferFee(address vault, address payable feeRecipient) external;
+
+    function setFlowCaps(
+        address vault,
+        FlowCapsConfig[] calldata config
+    ) external;
+
+    function flowCaps(
+        address vault,
+        Id
+    ) external view returns (FlowCaps memory);
+}

--- a/smart-contracts/contracts/libraries/ConstantsLib.sol
+++ b/smart-contracts/contracts/libraries/ConstantsLib.sol
@@ -44,4 +44,7 @@ library ConstantsLib {
     /// @notice Maximum rate at target per second (scaled by WAD).
     /// @dev Maximum rate at target = 200% (maximum rate = 800%).
     int256 public constant MAX_RATE_AT_TARGET = 2.0 ether / int256(365 days);
+
+    /// @dev The default value of the initiator of the multicall transaction is not the address zero to save gas.
+    address constant UNSET_INITIATOR = address(1);
 }

--- a/smart-contracts/hardhat.config.ts
+++ b/smart-contracts/hardhat.config.ts
@@ -35,6 +35,11 @@ const config: HardhatUserConfig = {
       accounts: privateKey !== undefined ? [privateKey] : [],
       gasPrice: 1 * 10 ** 9,
     },
+    flow: {
+      url: 'https://testnet.evm.nodes.onflow.org',
+      accounts: [privateKey], // In practice, this should come from an environment variable and not be commited
+      gas: 500000, // Example gas limit
+    },
   },
   solidity: {
     compilers: [
@@ -60,10 +65,48 @@ const config: HardhatUserConfig = {
           evmVersion: "paris",
         },
       },
+      {
+        version: "0.8.13",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 4000,
+          },
+          viaIR: true,
+          evmVersion: "paris",
+        },
+      },
+      {
+        version: "0.8.20",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 4000,
+          },
+          viaIR: true,
+          evmVersion: "paris",
+        },
+      },
     ],
   },
   gasReporter: {
     enabled: true,
+  },
+  etherscan: {
+    apiKey: {
+      // Is not required by blockscout. Can be any non-empty string
+      'flow': "abc"
+    },
+    customChains: [
+      {
+        network: "flow",
+        chainId: 545,
+        urls: {
+          apiURL: "https://evm-testnet.flowscan.io/api",
+          browserURL: "https://evm-testnet.flowscan.io/",
+        }
+      }
+    ]
   },
 };
 

--- a/smart-contracts/script/CreateNewVaults.s.sol
+++ b/smart-contracts/script/CreateNewVaults.s.sol
@@ -13,7 +13,7 @@ contract CreateNewVaults is Script {
         uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
         vaultsFactory = MoreVaultsFactory(vm.envAddress("VAULTS_FACTORY"));
 
-        address initialOwner = "0x0000000000000000000000000000000000000000";
+        address initialOwner = 0x0000000000000000000000000000000000000000;
         uint256 initialTimelock = 12345;
         address asset = 0x0000000000000000000000000000000000000000;
         string memory name = "MOCK_VAULT";

--- a/smart-contracts/scripts/vaultsfactory.js
+++ b/smart-contracts/scripts/vaultsfactory.js
@@ -1,0 +1,24 @@
+const { ethers } = require("hardhat");
+
+async function main() {
+  const [owner] = await ethers.getSigners();
+
+  // const vaultsFactory = await ethers.getContractAt("MoreVaultsFactory", "0xb21fa39418F3AbBAE407124896B84980E7149b3e");
+  // await vaultsFactory.createMetaMorpho(
+  //   // owner.address,
+  //   "0x2690eef879df58b97ec7cf830f7627fb1b51f826",
+  //   1000,
+  //   "0xC4F1dFC005Cb2285b8A9Ede7c525b0eEdF24F5db",
+  //   "doge vault",
+  //   "dogevault",
+  //   "0x4d434b564c543111000000000000000000000000000000000000000000000000"
+  // )
+
+  const tokenInfo = await ethers.getContractAt("ERC20Mock", "0xC4F1dFC005Cb2285b8A9Ede7c525b0eEdF24F5db");
+  console.log(await tokenInfo.name());
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Main updates
- add `premFees` and `setPremFee` for additional fee for premium users
- update logic so `feeRecipient` can receive the additional fee directly from user
- update test cases according to contract updates